### PR TITLE
new_with_options will only pass argv if the class has an argv attribute

### DIFF
--- a/lib/MooseX/Getopt/Basic.pm
+++ b/lib/MooseX/Getopt/Basic.pm
@@ -99,11 +99,16 @@ sub new_with_options {
 
     my $pa = $class->process_argv(@params);
 
+    # $pa->constructor_params contains everything passed to new_with_options,
+    # so it may contain the "argv" key, which $class 
+    my %constructor_params = %{ $pa->constructor_params };
+    delete $constructor_params{argv} if (not $class->meta->find_attribute_by_name('argv'));
+
     $class->new(
         ARGV       => $pa->argv_copy,
         extra_argv => $pa->extra_argv,
         ( $pa->usage ? ( usage => $pa->usage ) : () ),
-        %{ $pa->constructor_params }, # explicit params to ->new
+        %constructor_params,  # explicit params to ->new
         %{ $pa->cli_params }, # params from CLI
     );
 }

--- a/t/113_moosex_strictconstructor.t
+++ b/t/113_moosex_strictconstructor.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Requires 'MooseX::StrictConstructor';    # skip all if not installed
+
+package Test1 {
+ use Moose;
+ with 'MooseX::Getopt';
+ use MooseX::StrictConstructor;
+
+ has att1 => (is => 'ro', isa => 'Str');
+};
+
+my $o1;
+lives_ok {
+  $o1 = Test1->new_with_options(argv => [ '--att1', 'value1' ]);
+} 'new_with_options + argv on a MooseX::StrictConstructor enabled class';
+
+cmp_ok($o1->att1, 'eq', 'value1', 'att1 gets initialized correctly');
+
+
+package Test2 {
+ use Moose;
+ with 'MooseX::Getopt';
+ use MooseX::StrictConstructor;
+
+ has argv => (is => 'ro');
+ has att1 => (is => 'ro', isa => 'Str');
+};
+
+my $o2;
+lives_ok {
+  $o2 = Test2->new_with_options(argv => [ '--att1', 'value1' ]);
+} 'new_with_options + argv on a MooseX::StrictConstructor enabled class';
+
+cmp_ok($o2->att1, 'eq', 'value1', 'att1 gets initialized correctly');
+is_deeply($o2->argv, ['--att1', 'value1'], 'attribute argv is correct too');
+
+done_testing;

--- a/t/113_moosex_strictconstructor.t
+++ b/t/113_moosex_strictconstructor.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Exception;
+use Test::Fatal qw/lives_ok/;
 use Test::Requires 'MooseX::StrictConstructor';    # skip all if not installed
 
 package Test1 {
@@ -16,7 +16,7 @@ package Test1 {
 
 my $o1;
 lives_ok {
-  $o1 = Test1->new_with_options(argv => [ '--att1', 'value1' ]);
+  return $o1 = Test1->new_with_options(argv => [ '--att1', 'value1' ]);
 } 'new_with_options + argv on a MooseX::StrictConstructor enabled class';
 
 cmp_ok($o1->att1, 'eq', 'value1', 'att1 gets initialized correctly');
@@ -33,7 +33,7 @@ package Test2 {
 
 my $o2;
 lives_ok {
-  $o2 = Test2->new_with_options(argv => [ '--att1', 'value1' ]);
+  return $o2 = Test2->new_with_options(argv => [ '--att1', 'value1' ]);
 } 'new_with_options + argv on a MooseX::StrictConstructor enabled class';
 
 cmp_ok($o2->att1, 'eq', 'value1', 'att1 gets initialized correctly');


### PR DESCRIPTION
Hi,

   This is the fix for bug #101938 reported on CPAN RT

Best Regards,

Jose Luis Martinez
