### PR TITLE
Ignore attributes with init_arg => undef

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for MooseX-Getopt
 
 {{$NEXT}}
+ - In 0.69, an undefined init_arg would cause warnings and exception.
+   Attributes with an undefined init_arg are now ignored.
 
 0.69      2016-04-22 11:27:12Z
  - attributes' "init_arg" settings are now respected when retrieving command

--- a/lib/MooseX/Getopt/Basic.pm
+++ b/lib/MooseX/Getopt/Basic.pm
@@ -207,6 +207,7 @@ sub _traditional_spec {
 sub _compute_getopt_attrs {
     my $class = shift;
     sort { $a->insertion_order <=> $b->insertion_order }
+    grep { defined $_->init_arg }
     grep {
         $_->does("MooseX::Getopt::Meta::Attribute::Trait")
             or

--- a/t/114_init_arg.t
+++ b/t/114_init_arg.t
@@ -11,6 +11,7 @@ use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 
     has name_after => ( is => 'ro', isa => 'Str', init_arg => 'name_before' );
     has bar => ( is => 'ro', isa => 'Str', );
+    has undefined_init_arg => ( is => 'ro', isa => 'Str', init_arg => undef );
 };
 
 {


### PR DESCRIPTION
After upgrading to 0.69, we ran into the following issue on some of our classes that used `init_arg => undef`:

```
Use of uninitialized value $flag in join or string at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/Basic.pm line 243.
Use of uninitialized value in lc at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/GLD.pm line 75.
perverse option names given:  at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Getopt/Long/Descriptive/Opts.pm line 93.
	Getopt::Long::Descriptive::Opts::___class_for_opt("Getopt::Long::Descriptive::Opts", HASH(0x2b661c8)) called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Getopt/Long/Descriptive/Opts.pm line 115
	Getopt::Long::Descriptive::Opts::___new_opt_obj("Getopt::Long::Descriptive::Opts", HASH(0x2b661c8)) called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Getopt/Long/Descriptive.pm line 474
	Getopt::Long::Descriptive::__ANON__("usage: %c %o", ARRAY(0x2b5adb8), ARRAY(0x2b5b850), ARRAY(0x2b5b700), ARRAY(0x2b5b760)) called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Getopt/Long/Descriptive.pm line 328
	Getopt::Long::Descriptive::describe_options("usage: %c %o", ARRAY(0x2b5adb8), ARRAY(0x2b5b850), ARRAY(0x2b5b700), ARRAY(0x2b5b760), HASH(0x2b5bb68)) called at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/GLD.pm line 49
	Class::MOP::Class:::around(CODE(0x2ac8750), "Test1", HASH(0x2ab6780), ARRAY(0x2a40a30)) called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/x86_64-linux/Class/MOP/Method/Wrapped.pm line 164
	Test1::_wrapped__getopt_get_options("Test1", HASH(0x2ab6780), ARRAY(0x2a40a30)) called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/x86_64-linux/Class/MOP/Method/Wrapped.pm line 95
	Test1::_getopt_get_options("Test1", HASH(0x2ab6780), ARRAY(0x2a40a30)) called at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/Basic.pm line 134
	MooseX::Getopt::Basic::try {...} () called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Try/Tiny.pm line 88
	eval {...} called at /home/greg/perl5/perlbrew/perls/perl-5.20.2/lib/site_perl/5.20.2/Try/Tiny.pm line 83
	Try::Tiny::try(CODE(0x2b5b0e8), Try::Tiny::Catch=REF(0x2b5ab38)) called at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/Basic.pm line 138
	MooseX::Getopt::Basic::_parse_argv("Test1", "options", ARRAY(0x2b5a898), "params", HASH(0x2b5a8e0)) called at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/Basic.pm line 76
	MooseX::Getopt::Basic::process_argv("Test1", "argv", ARRAY(0x2b5a370)) called at /home/greg/MaxMind/MooseX-Getopt/lib/MooseX/Getopt/Basic.pm line 102
	MooseX::Getopt::Basic::new_with_options("Test1", "argv", ARRAY(0x2b5a370)) called at t/114_init_arg.t line 27
```