### PR TITLE
Make after print_usage_text method modifier work.

### DIFF
--- a/lib/MooseX/Getopt/Basic.pm
+++ b/lib/MooseX/Getopt/Basic.pm
@@ -85,6 +85,7 @@ sub process_argv {
     # did the user request usage information?
     if ( $processed{usage} and $params->{help_flag} ) {
         $class->print_usage_text($processed{usage});
+        exit 0;
     }
 
     return MooseX::Getopt::ProcessedArgv->new(
@@ -175,7 +176,6 @@ sub _getopt_full_usage
 {
     my ($self, $usage) = @_;
     print $usage->text;
-    exit 0;
 }
 #(this is already documented in MooseX::Getopt. But FIXME later, via RT#82195)
 =for Pod::Coverage

--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -55,6 +55,22 @@ my $usage = qr/^\Qusage: 104_override_usage.t [-?h] [long options...]\E
 }
 
 {
+    find_meta('MyScript')->add_after_method_modifier(
+        print_usage_text => sub {
+            print "--- DOCUMENTATION ---\n";
+        },
+    );
+
+    local @ARGV = ('--help');
+    trap { MyScript->new_with_options };
+    like(
+        $trap->stdout,
+        qr/$usage\n--- DOCUMENTATION ---\n/,
+        'additional text included before normal usage string',
+    );
+}
+
+{
     package MyScript2;
     use Moose;
 


### PR DESCRIPTION
"after" method modifiers on print_usage_text were previously impossible
as print_usage_text called exit, so the after method modifier would
never fire.

Moved the exit call to where print_usage_text was called from instead.