### PR TITLE
Fix treatment of newlines in documentation attribute

### DIFF
--- a/lib/MooseX/Getopt/Basic.pm
+++ b/lib/MooseX/Getopt/Basic.pm
@@ -254,7 +254,7 @@ sub _attrs_to_options {
             }
         }
 
-        push @options, {
+        my $push = {
             name       => $flag,
             init_arg   => $attr->init_arg,
             opt_string => $opt_string,
@@ -268,8 +268,13 @@ sub _attrs_to_options {
             # See 100_gld_default_bug.t for an example
             # - SL
             #( ( $attr->has_default && ( $attr->is_default_a_coderef xor $attr->is_lazy ) ) ? ( default => $attr->default({}) ) : () ),
-            ( $attr->has_documentation ? ( doc => $attr->documentation ) : () ),
+        };
+        if ($attr->has_documentation) {
+            my $doc = $attr->documentation;
+            $doc =~ s/[\r\n]+/ /g;
+            $push->{doc} = $doc;
         }
+        push @options, $push;
     }
 
     return @options;

--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -12,12 +12,14 @@ use Moose::Util 'find_meta';
 
     with 'MooseX::Getopt';
 
-    has foo => ( isa => 'Int', is => 'ro', documentation => 'A foo' );
+    has foo => ( isa => 'Int', is => 'ro', documentation => 'A foo
+with newline and some 123456789 123456789 123456789 characters' );
 }
 
 my $usage = qr/^\Qusage: 104_override_usage.t [-?h] [long options...]\E
 \t-h -\? --usage --help\s+Prints this usage information\.
-\t--foo (INT)?\s+A foo$/m;
+\t--foo (INT)?\s+A foo .+
+\t\s+.+characters/m;
 
 {
     local @ARGV = ('--foo', '1');
@@ -59,7 +61,8 @@ my $usage = qr/^\Qusage: 104_override_usage.t [-?h] [long options...]\E
     use Moose;
 
     with 'MooseX::Getopt';
-    has foo => ( isa => 'Int', is => 'ro', documentation => 'A foo' );
+    has foo => ( isa => 'Int', is => 'ro', documentation => 'A foo
+with newline and some 123456789 123456789 123456789 characters' );
 }
 
 {


### PR DESCRIPTION
- newlines in documentation attr now are replaced by a space before wrapping happens
- previous behaviour was that the string after the newline appeared as left-justified in the output
- test 104_override_usage.t is tweaked to deal with such a case